### PR TITLE
fix(BUG-15): revertir requiresOnDeviceRecognition a false

### DIFF
--- a/app/src/hooks/useVoiceDetection.ts
+++ b/app/src/hooks/useVoiceDetection.ts
@@ -22,7 +22,7 @@ const RECOGNITION_OPTIONS = {
   lang: 'es-ES',
   continuous: true,
   interimResults: true,
-  requiresOnDeviceRecognition: true,
+  requiresOnDeviceRecognition: false,
 };
 
 // Verifica disponibilidad del módulo nativo una sola vez al cargar.


### PR DESCRIPTION
## Descripción

Revierte `requiresOnDeviceRecognition: true` → `false` en `useVoiceDetection.ts`.

## Causa raíz

En Sprint 2 se activó el reconocimiento on-device para reducir latencia. Si el dispositivo no tiene el modelo español instalado, Android falla silenciosamente sin fallback a red — el reconocedor arranca pero nunca emite resultados.

## Fix

Con `requiresOnDeviceRecognition: false`, Android intenta on-device primero y si no tiene el modelo usa la red. Funciona en cualquier dispositivo. El cambio `lang: es-ES` se mantiene.

## Verificaciones
- `npx tsc --noEmit` → sin errores
- `npx jest --no-coverage` → 70/70 tests pasando

Closes #15

## Summary by Sourcery

Bug Fixes:
- Disable mandatory on-device speech recognition by setting requiresOnDeviceRecognition to false in the voice detection hook, restoring functionality on devices without the Spanish on-device model.