### PR TITLE
fix(BUG-16): reemplazar tick incremental por timestamp absoluto

### DIFF
--- a/app/src/hooks/useCountdown.ts
+++ b/app/src/hooks/useCountdown.ts
@@ -1,44 +1,35 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useTimerStore } from '@src/store/timerStore';
 
 const TICK_INTERVAL_MS = 100;
 
 /**
  * Maneja el countdown del timer.
- * Corre un setInterval a 100ms para mayor precisión,
- * pero actualiza timeRemainingMs en milisegundos reales.
- * Dispara onTimeout() cuando el tiempo llega a 0.
+ * Usa un punto de referencia absoluto (startedAt) para calcular el tiempo
+ * restante, en lugar de acumular elapsed incremental. Esto es inmune a
+ * delays del JS thread (carga de assets, audio) que causaban BUG-16.
  */
 export function useCountdown() {
   const status = useTimerStore((s) => s.status);
-  const tick = useTimerStore((s) => s.tick);
+  const setTimeRemaining = useTimerStore((s) => s.setTimeRemaining);
   const onTimeout = useTimerStore((s) => s.onTimeout);
   const timeRemainingMs = useTimerStore((s) => s.timeRemainingMs);
-
-  const lastTickRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (status !== 'running') return;
 
-    // Inicializamos lastTickRef al primer tick real del intervalo,
-    // no al montar el efecto, para evitar que tiempo de setup
-    // se cuente como tiempo de juego (causa BUG-01: segundos rápidos).
-    lastTickRef.current = null;
+    // Capturamos el punto de referencia absoluto al inicio del período running.
+    // useTimerStore.getState() lee el valor actual sin suscripción reactiva.
+    const startedAt = Date.now();
+    const remainingAtStart = useTimerStore.getState().timeRemainingMs;
 
     const interval = setInterval(() => {
-      const now = Date.now();
-      if (lastTickRef.current === null) {
-        // Primer tick: solo establecemos la marca de tiempo sin descontar
-        lastTickRef.current = now;
-        return;
-      }
-      const elapsed = now - lastTickRef.current;
-      lastTickRef.current = now;
-      tick(elapsed);
+      const remaining = remainingAtStart - (Date.now() - startedAt);
+      setTimeRemaining(remaining);
     }, TICK_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [status, tick]);
+  }, [status, setTimeRemaining]);
 
   // Disparar timeout cuando el tiempo llega a 0 mientras está corriendo
   useEffect(() => {

--- a/app/src/store/timerStore.ts
+++ b/app/src/store/timerStore.ts
@@ -40,6 +40,7 @@ interface TimerState {
   endTransition: () => void;
   finish: () => void;
   tick: (elapsedMs: number) => void;
+  setTimeRemaining: (ms: number) => void;
   setWinner: (playerId: string | null) => void;
   reset: () => void;
 }
@@ -168,6 +169,12 @@ function createActions(set: (fn: (s: TimerState) => Partial<TimerState>) => void
 
     setWinner: (playerId: string | null) =>
       set(() => ({ winnerId: playerId })),
+
+    setTimeRemaining: (ms: number) =>
+      set((s) => {
+        if (s.status !== 'running') return {};
+        return { timeRemainingMs: Math.max(0, ms) };
+      }),
 
     tick: (elapsedMs: number) =>
       set((s) => {


### PR DESCRIPTION
## Descripción

Reemplaza la estrategia de tick incremental en `useCountdown` por un enfoque de timestamp absoluto, eliminando la regresión donde el timer corría ~2x más rápido.

## Causa raíz

El tick incremental (`elapsed = now - lastTickRef`) es vulnerable a delays del JS thread. El `useAudio` de Sprint 2 carga 5 audios al montar, bloqueando el thread brevemente en Android. Los callbacks del `setInterval` se acumulan y disparan en ráfaga, haciendo que el timer avance demasiado rápido.

## Fix

Al inicio de cada período `running` se captura `startedAt = Date.now()` y `remainingAtStart`. Cada tick calcula:

```ts
remaining = remainingAtStart - (Date.now() - startedAt)
```

No importa cuántos ticks se acumulen — el tiempo restante siempre es correcto porque se mide contra un punto fijo.

Se agrega `setTimeRemaining(ms)` al store para establecer el valor directamente.

## Verificaciones
- `npx tsc --noEmit` → sin errores
- `npx jest --no-coverage` → 70/70 tests pasando

Closes #16

## Summary by Sourcery

Replace the countdown timer’s incremental tick calculation with an absolute timestamp–based countdown to make timing robust against JS thread delays.

Bug Fixes:
- Fix countdown running faster than real time when JS thread is delayed (e.g., during audio loading) by basing remaining time on an absolute start timestamp instead of accumulated elapsed ticks.

Enhancements:
- Expose a setTimeRemaining(ms) action in the timer store to allow directly setting clamped remaining time while the timer is running.