### PR TITLE
feat(#19): animación de splash al inicio de la app

### DIFF
--- a/app/screens/_layout.tsx
+++ b/app/screens/_layout.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
+import { SplashAnimation } from '@src/components/common/SplashAnimation';
 import {
   useFonts,
   Fraunces_300Light,
@@ -25,7 +26,11 @@ import {
 // Evita que el splash se oculte antes de cargar las fuentes
 SplashScreen.preventAutoHideAsync();
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const ICON = require('../assets/images/icon.png') as number;
+
 export default function RootLayout() {
+  const [showSplash, setShowSplash] = useState(true);
   const [fontsLoaded, fontError] = useFonts({
     Fraunces_300Light,
     Fraunces_400Regular,
@@ -40,8 +45,13 @@ export default function RootLayout() {
     JetBrainsMono_600SemiBold,
   });
 
+  const handleSplashFinish = useCallback(() => {
+    setShowSplash(false);
+  }, []);
+
   useEffect(() => {
     if (fontsLoaded || fontError) {
+      // Ocultamos el splash nativo; el animado toma el relevo
       SplashScreen.hideAsync();
     }
   }, [fontsLoaded, fontError]);
@@ -54,6 +64,9 @@ export default function RootLayout() {
     <SafeAreaProvider>
       <Stack screenOptions={{ headerShown: false }} />
       <StatusBar style="auto" />
+      {showSplash && (
+        <SplashAnimation source={ICON} onFinish={handleSplashFinish} />
+      )}
     </SafeAreaProvider>
   );
 }

--- a/app/src/components/common/SplashAnimation.tsx
+++ b/app/src/components/common/SplashAnimation.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { View, Image, StyleSheet, ImageSourcePropType } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withSequence,
+  runOnJS,
+  Easing,
+} from 'react-native-reanimated';
+
+interface SplashAnimationProps {
+  source: ImageSourcePropType;
+  onFinish: () => void;
+}
+
+export function SplashAnimation({ source, onFinish }: SplashAnimationProps) {
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(0.5);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  useEffect(() => {
+    // Escala: aparece con overshoot → se asienta → mantiene → crece suavemente al salir
+    scale.value = withSequence(
+      withTiming(1.1, { duration: 300, easing: Easing.out(Easing.back(2)) }),
+      withTiming(1.0, { duration: 200, easing: Easing.out(Easing.ease) }),
+      withTiming(1.0, { duration: 1500 }),
+      withTiming(1.06, { duration: 600, easing: Easing.in(Easing.ease) }),
+    );
+
+    // Opacidad: fade in → mantiene → fade out; llama a onFinish al terminar
+    opacity.value = withSequence(
+      withTiming(1, { duration: 500, easing: Easing.out(Easing.ease) }),
+      withTiming(1, { duration: 1500 }),
+      withTiming(0, { duration: 600, easing: Easing.in(Easing.ease) }, (finished) => {
+        if (finished) runOnJS(onFinish)();
+      }),
+    );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Animated.View style={animatedStyle}>
+        <Image source={source} style={styles.logo} resizeMode="contain" />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#FAF6F0',
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 999,
+  },
+  logo: {
+    width: 160,
+    height: 160,
+  },
+});


### PR DESCRIPTION
Agrega `SplashAnimation` — animación de 2.6s con el ícono de la app al inicio.

- Bounce overshoot → settle → hold → fade out con leve crecimiento
- Reemplaza el splash nativo estático de forma invisible (mismo fondo `#FAF6F0`)
- Reanimated 2: `withSequence`, `withTiming`, `runOnJS`

Closes #19

## Summary by Sourcery

Add an animated splash screen that seamlessly replaces the native static splash at app startup.

New Features:
- Introduce a `SplashAnimation` component that plays a timed scale and fade animation for the app icon on launch.

Enhancements:
- Integrate the animated splash into the root layout with conditional rendering and a completion callback tied to app initialization state.