### PR TITLE
fix(BUG-22): listeners nativos estables con shouldListenRef + fatalErrorRef

### DIFF
--- a/app/src/hooks/useVoiceDetection.ts
+++ b/app/src/hooks/useVoiceDetection.ts
@@ -17,7 +17,6 @@ interface UseVoiceDetectionResult {
 }
 
 const DEFAULT_TRIGGER = 'paso';
-// BUG-03: preferimos reconocimiento en dispositivo para reducir latencia
 const RECOGNITION_OPTIONS = {
   lang: 'es-ES',
   continuous: true,
@@ -68,6 +67,15 @@ export function useVoiceDetection({
   const shouldListen = enabled && permissionRef.current === true
     && (status === 'running' || status === 'timeout');
 
+  // BUG-22: ref sincronizada con shouldListen para usarla en closures de event handlers
+  // sin poner shouldListen en las deps del effect de suscripciones.
+  const shouldListenRef = useRef(shouldListen);
+  useEffect(() => { shouldListenRef.current = shouldListen; }, [shouldListen]);
+
+  // BUG-22: ref para saber si el cierre de sesión fue por error fatal.
+  // El handler de 'end' consulta esta ref para no reiniciar tras un error no-recuperable.
+  const fatalErrorRef = useRef(false);
+
   // ── Iniciar / detener reconocimiento ──────────────────────────────────
   const startListening = useCallback(() => {
     if (!SpeechModule || isRunningRef.current) return;
@@ -93,8 +101,9 @@ export function useVoiceDetection({
   }, []);
 
   // ── Suscripción a eventos nativos ──────────────────────────────────────
-  // Se usa addListener directamente para evitar depender de useSpeechRecognitionEvent,
-  // que falla en Expo Go al no encontrar el módulo nativo.
+  // BUG-22: los handlers usan shouldListenRef.current en lugar de shouldListen
+  // para tener siempre el valor más reciente sin recrear los listeners en cada
+  // transición de turno. 'shouldListen' ya no está en las deps de este effect.
   useEffect(() => {
     if (!SpeechModule || !enabled) return;
 
@@ -106,9 +115,14 @@ export function useVoiceDetection({
 
       SpeechModule.addListener('end', () => {
         isRunningRef.current = false;
-        if (shouldListen) {
+        // BUG-22: no reiniciar si el cierre fue por error fatal
+        if (fatalErrorRef.current) {
+          fatalErrorRef.current = false;
+          return;
+        }
+        if (shouldListenRef.current) {
           setTimeout(() => {
-            if (shouldListen && !isRunningRef.current) startListening();
+            if (shouldListenRef.current && !isRunningRef.current) startListening();
           }, 300);
         }
       }),
@@ -117,18 +131,19 @@ export function useVoiceDetection({
         const event = data as { error: string };
         isRunningRef.current = false;
         const recoverable = ['no-speech', 'speech-timeout', 'aborted', 'network'];
-        if (recoverable.includes(event.error) && shouldListen) {
+        if (recoverable.includes(event.error) && shouldListenRef.current) {
           setTimeout(() => {
-            if (shouldListen && !isRunningRef.current) startListening();
+            if (shouldListenRef.current && !isRunningRef.current) startListening();
           }, 500);
         } else {
+          // BUG-22: marcar error fatal para que 'end' no reactive el reconocedor
+          fatalErrorRef.current = true;
           setVoiceState('error');
         }
       }),
 
       SpeechModule.addListener('result', (data: unknown) => {
-        if (!shouldListen) return;
-        // BUG-03: debounce reducido de 1500ms a 800ms para menor latencia
+        if (!shouldListenRef.current) return;
         const event = data as { results: Array<{ transcript: string; isFinal?: boolean }> };
         const now = Date.now();
         if (now - lastTriggerRef.current < 800) return;
@@ -144,7 +159,8 @@ export function useVoiceDetection({
     ];
 
     return () => subs.forEach((s) => s.remove());
-  }, [enabled, shouldListen, triggerWord, startListening, passTurn, onTrigger]);
+  // BUG-22: 'shouldListen' eliminado de deps — los closures usan shouldListenRef.current
+  }, [enabled, triggerWord, startListening, passTurn, onTrigger]);
 
   // ── Control start/stop según estado del timer ──────────────────────────
   useEffect(() => {

--- a/docs/desarrollo/bugs/BUG-22/reporte.md
+++ b/docs/desarrollo/bugs/BUG-22/reporte.md
@@ -1,0 +1,89 @@
+# BUG-22 — Reconocimiento de voz no detecta "paso" — flicker paused/listening constante
+
+**Issue:** rodrigow1985/board-buddy#22
+**Fecha reporte:** 2026-04-26
+**Severidad:** Alta
+**Estado:** Abierto
+
+---
+
+## Descripción
+El reconocimiento de voz nunca detecta "paso". El indicador de estado alterna constantemente entre "pausado" y "escuchando" sin procesar resultados de transcripción.
+
+## Pasos para reproducir
+1. Instalar build preview
+2. Iniciar una partida con voz habilitada
+3. Decir "paso" durante el turno de un jugador
+4. Observar el chip de estado de voz
+
+## Comportamiento esperado
+El reconocedor permanece estable en "escuchando" y detecta la palabra "paso".
+
+## Comportamiento actual
+El indicador alterna constantemente entre "pausado" y "escuchando". Nunca se detecta "paso".
+
+## Entorno
+- Build: preview (EAS)
+- Plataforma: Android
+
+---
+
+## Análisis
+
+### Causa raíz
+
+Dos problemas combinados en `useVoiceDetection.ts`:
+
+#### Problema 1 — Stale closure en los event listeners nativos
+
+`shouldListen` está en el array de deps del effect de suscripciones (línea 147):
+
+```ts
+}, [enabled, shouldListen, triggerWord, startListening, passTurn, onTrigger]);
+```
+
+Cada vez que `shouldListen` cambia — lo que ocurre en cada transición de turno
+(`running → transitioning → running`) — React elimina todos los listeners nativos
+y los re-registra. Durante ese ciclo:
+
+1. Cleanup del effect de suscripciones → listeners nativos eliminados
+2. Cleanup del control effect → `SpeechModule.abort()` → `isRunningRef.current = false`
+3. Control effect re-ejecuta: `shouldListen = false` → `stopListening()` → estado **"paused"**
+4. `shouldListen` vuelve a true → `startListening()` → estado **"listening"**
+
+Esto explica el flicker. Además, reiniciar el reconocedor en cada cambio de turno
+rompe el contexto de escucha de Android.
+
+Los valores `shouldListen` dentro de los closures de `end`, `error` y `result`
+quedan obsoletos mientras los listeners están activos, aunque el effect los re-registra.
+La solución es usar una ref sincronizada en lugar de poner `shouldListen` en las deps.
+
+#### Problema 2 — El handler de `end` reactiva tras errores fatales
+
+Cuando Android lanza un error no-recuperable (ej. `service-not-available`):
+1. `error` handler → `setVoiceState('error')`, sin reiniciar
+2. `end` handler (llega justo después) → `shouldListen = true` → reinicia de todos modos
+
+Ciclo: error fatal → end → restart → error fatal → ...
+
+El handler de `end` no sabe si el cierre de sesión fue por error fatal,
+por lo que reactiva el reconocedor en un estado no válido.
+
+### Archivos afectados
+- `app/src/hooks/useVoiceDetection.ts` — suscripciones con stale closure y lógica de reinicio tras error fatal
+
+---
+
+## Plan de solución
+
+1. **Reemplazar `shouldListen` en closures por `shouldListenRef.current`**: agregar
+   `const shouldListenRef = useRef(shouldListen)` y un effect que lo sincronice.
+   Los event handlers usan `shouldListenRef.current` para leer el valor más reciente
+   sin estar en las deps del effect de suscripciones.
+
+2. **Eliminar `shouldListen` de las deps del effect de suscripciones**: los listeners
+   nativos se registran una sola vez (por `enabled`) y no se re-crean en cada transición.
+
+3. **Agregar `fatalErrorRef`**: booleano que el handler de `error` activa cuando el error
+   no es recuperable. El handler de `end` lo consulta y, si está activo, no reinicia
+   (y lo resetea para no bloquear intentos futuros manuales).


### PR DESCRIPTION
## Causa raíz

Dos problemas en `useVoiceDetection`:

1. **`shouldListen` en deps** del effect de suscripciones → listeners nativos eliminados y re-creados en cada transición de turno → ciclo `stopListening/startListening` → flicker paused/listening + contexto del reconocedor roto.

2. **`end` reactiva tras error fatal** → el handler de `end` no sabía si el cierre fue por error no-recuperable, reiniciando el reconocedor en un estado inválido.

## Fix

- `shouldListenRef` sincronizado con un effect separado; los handlers usan `.current` en lugar de la closure. `shouldListen` eliminado de las deps del effect de suscripciones → listeners registrados una sola vez.
- `fatalErrorRef` activado en errores no-recuperables; `end` lo consulta y aborta el reinicio automático.

## Verificaciones
- `npx tsc --noEmit` → sin errores
- `npx jest --no-coverage` → 70/70 tests pasando

Closes #22

## Summary by Sourcery

Stabilize native voice recognition listeners and prevent automatic restarts after fatal errors in the voice detection hook.

Bug Fixes:
- Ensure native speech recognition listeners are registered once and remain stable across turn transitions by decoupling them from shouldListen state changes.
- Prevent the speech recognizer from automatically restarting after non-recoverable errors by tracking fatal error state in the voice detection lifecycle.

Documentation:
- Add a detailed BUG-22 report documenting the voice recognition flicker issue, root cause analysis, and remediation plan.