### PR TITLE
fix(BUG-25): barra de navegación de Android con fondo negro

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,6 +23,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-linking": "~8.0.11",
+        "expo-navigation-bar": "~5.0.10",
         "expo-router": "~6.0.23",
         "expo-speech-recognition": "^3.1.3",
         "expo-splash-screen": "~31.0.13",
@@ -7251,6 +7252,22 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-navigation-bar": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/expo-navigation-bar/-/expo-navigation-bar-5.0.10.tgz",
+      "integrity": "sha512-r9rdLw8mY6GPMQmVVOY/r1NBBw74DZefXHF60HxhRsdNI2kjc1wLdfWfR2rk4JVdOvdMDujnGrc9HQmqM3n8Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.2",
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linking": "~8.0.11",
+    "expo-navigation-bar": "~5.0.10",
     "expo-router": "~6.0.23",
     "expo-speech-recognition": "^3.1.3",
     "expo-splash-screen": "~31.0.13",

--- a/app/screens/games/rummikub/timer.tsx
+++ b/app/screens/games/rummikub/timer.tsx
@@ -6,10 +6,12 @@ import {
   StyleSheet,
   Animated,
   Dimensions,
+  Platform,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as NavigationBar from 'expo-navigation-bar';
 import { useTimerStore, TimerStatus } from '@src/store/timerStore';
 import { useSettingsStore } from '@src/store/settingsStore';
 import { useCountdown } from '@src/hooks/useCountdown';
@@ -139,6 +141,17 @@ export default function TimerScreen() {
     inputRange: [0, 1, 2, 3],
     outputRange: BG_COLORS,
   });
+
+  // ── BUG-25: sincronizar nav bar de Android con el color de fondo del timer ─
+  // edgeToEdgeEnabled: true extiende el contenido detrás de la nav bar, pero
+  // Android dibuja un scrim negro por defecto. Hacemos la nav bar transparente
+  // y usamos el mismo color que el fondo de la pantalla.
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const color = BG_COLORS[bgIndexForStatus(status, isWarn)];
+    NavigationBar.setBackgroundColorAsync(color);
+    NavigationBar.setButtonStyleAsync('light');
+  }, [status, isWarn]);
 
   // ── Flash rojo en timeout ──────────────────────────────────────────────────
   const flashAnim = useRef(new Animated.Value(0)).current;

--- a/docs/desarrollo/bugs/BUG-25/informe.md
+++ b/docs/desarrollo/bugs/BUG-25/informe.md
@@ -1,0 +1,37 @@
+# Informe BUG-25 — Barra de navegación de Android visible con fondo negro en timer
+
+**Fecha:** 2026-04-27
+**Commit:** `7525719`
+**Issue cerrado:** rodrigow1985/board-buddy#25
+**Rama:** `bug/25-navbar-android-negro`
+
+---
+
+## Causa raíz
+
+Con `edgeToEdgeEnabled: true` en `app.json` (Expo SDK 54), Android extiende el contenido de la app detrás de la barra de navegación del sistema. Sin embargo, el sistema dibuja un scrim negro detrás de los botones para darles visibilidad, y ese fondo quedaba negro porque la app no configuraba `expo-navigation-bar`.
+
+## Cambios
+
+### `app/screens/games/rummikub/timer.tsx`
+
+```ts
+// Antes — sin configuración de nav bar, scrim negro del sistema
+// (no había ningún código relacionado)
+
+// Después — sincroniza el color de la nav bar con el estado del timer
+useEffect(() => {
+  if (Platform.OS !== 'android') return;
+  const color = BG_COLORS[bgIndexForStatus(status, isWarn)];
+  NavigationBar.setBackgroundColorAsync(color);
+  NavigationBar.setButtonStyleAsync('light');
+}, [status, isWarn]);
+```
+
+### `app/package.json`
+- Agregado: `expo-navigation-bar ~5.0.10`
+
+## Verificaciones
+
+- `npx tsc --noEmit` → sin errores
+- `npx jest --no-coverage` → 70/70 tests pasando

--- a/docs/desarrollo/bugs/BUG-25/reporte.md
+++ b/docs/desarrollo/bugs/BUG-25/reporte.md
@@ -1,0 +1,51 @@
+# BUG-25 — Barra de navegación de Android visible con fondo negro en timer
+
+**Issue:** rodrigow1985/board-buddy#25
+**Fecha reporte:** 2026-04-27
+**Severidad:** Media
+**Estado:** Abierto
+
+---
+
+## Descripción
+En la pantalla del timer, la barra de navegación de Android (botones |||, O, <) aparece superpuesta sobre el contenido, y debajo de los botones hay una barra negra sólida que no pertenece al diseño de la app.
+
+## Pasos para reproducir
+1. Instalar build preview en Android con navegación de 3 botones
+2. Iniciar una partida
+3. Observar la parte inferior de la pantalla del timer
+
+## Comportamiento esperado
+La barra de navegación de Android es transparente y el color de fondo de la app se extiende detrás de los botones sin mostrar un bloque negro.
+
+## Comportamiento actual
+- Los 3 botones de navegación del sistema son visibles como overlay
+- Debajo de los botones hay una barra negra sólida
+
+## Entorno
+- Build: preview (EAS)
+- Plataforma: Android (3-button navigation)
+
+---
+
+## Análisis
+
+### Causa raíz
+
+Con `edgeToEdgeEnabled: true` en `app.json` (Expo SDK 54), el contenido de la app se extiende detrás de la barra de navegación del sistema. Sin embargo:
+
+1. Android agrega un scrim oscuro/negro detrás de los botones de navegación para darles visibilidad
+2. La app no usa `expo-navigation-bar` para configurar ese fondo como transparente
+3. El color de la barra de navegación del sistema queda como negro opaco en lugar de transparente
+
+### Archivos afectados
+- `app/app.json` — `edgeToEdgeEnabled: true` activo sin configuración de navigation bar
+- `app/screens/games/rummikub/timer.tsx` — pantalla que necesita sincronizar el color de la nav bar
+
+---
+
+## Plan de solución
+
+1. **Instalar `expo-navigation-bar`** para controlar el estilo de la barra de navegación de Android
+2. **En `timer.tsx`**: usar `NavigationBar.setBackgroundColorAsync` para sincronizar el color de la barra de navegación con el estado del timer (verde, amarillo, rojo, gris)
+3. **Estilo de botones**: usar `NavigationBar.setButtonStyleAsync('light')` para que los iconos sean blancos (legibles sobre fondos oscuros)

--- a/docs/desarrollo/bugs/BUG-25/reporte.md
+++ b/docs/desarrollo/bugs/BUG-25/reporte.md
@@ -3,7 +3,7 @@
 **Issue:** rodrigow1985/board-buddy#25
 **Fecha reporte:** 2026-04-27
 **Severidad:** Media
-**Estado:** Abierto
+**Estado:** Cerrado ✓
 
 ---
 


### PR DESCRIPTION
Incluye el fix del BUG-25: sincronización del color de la barra de navegación de Android con el estado del timer usando `expo-navigation-bar`.

Closes #25

## Summary by Sourcery

Synchronize the Android system navigation bar appearance with the Rummikub timer screen background to remove the unwanted black bar and document BUG-25 resolution.

Bug Fixes:
- Align the Android navigation bar background color and button style with the timer screen state to eliminate the persistent black bar beneath system buttons.

Build:
- Add the expo-navigation-bar dependency to manage Android navigation bar appearance.

Documentation:
- Add BUG-25 report and post-fix summary documentation describing the root cause, solution, and verification steps.